### PR TITLE
Configure Poetry to not use Virtualenvs

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,14 @@ Or use the preview release (not compatible with the `version` option)
     preview: true
 ```
 
+By default, the Poetry option virtualenvs.create is set to `false`. If you would
+like Poetry to create a new virtual environment if one doesn't already exist:
+```yaml
+- uses: dschep/install-poetry-action@v1.2
+  with:
+    create_virtualenvs: true
+```
+
 # License
 
 The scripts and documentation in this project are released under the [MIT License](LICENSE)

--- a/src/main.ts
+++ b/src/main.ts
@@ -9,6 +9,7 @@ async function run() {
   try {
     const version = core.getInput('version');
     const preview = core.getInput('preview');
+    const create_virtualenvs = core.getInput('create_virtualenvs');
 
     await exec('curl -O -sSL https://raw.githubusercontent.com/sdispater/poetry/master/get-poetry.py');
 
@@ -16,6 +17,9 @@ async function run() {
     await exec(`python get-poetry.py --yes ${flags}`)
     core.addPath(path.join(os.homedir(), '.poetry', 'bin'));
     fs.unlinkSync('get-poetry.py');
+    if (!create_virtualenvs) {
+      await exec('poetry config virtualenvs.create false');
+    }
   } catch (error) {
     core.setFailed(error.message);
   }

--- a/src/main.ts
+++ b/src/main.ts
@@ -14,7 +14,7 @@ async function run() {
     await exec('curl -O -sSL https://raw.githubusercontent.com/sdispater/poetry/master/get-poetry.py');
 
     const flags = preview ? '--preview' : version ? `--version=${version}`: '';
-    await exec(`python get-poetry.py --yes ${flags}`)
+    await exec(`python get-poetry.py --yes ${flags}`);
     core.addPath(path.join(os.homedir(), '.poetry', 'bin'));
     fs.unlinkSync('get-poetry.py');
     if (!create_virtualenvs) {


### PR DESCRIPTION
Fixes #2.

By default sets Poetry to not use virtualenvs. If you do want to use a virtualenv, you can configure the action as follows:
```yaml
- uses: dschep/install-poetry-action@v1.2
  with:
    create_virtualenvs: true
```